### PR TITLE
Fix unreadable code color formatting

### DIFF
--- a/docs/css/html.css
+++ b/docs/css/html.css
@@ -53,6 +53,7 @@ kbd, samp { color: #000; font-family: monospace, monospace; _font-family: 'couri
 
 code, pre {
    font-family: Menlo, Monaco, Andale Mono, Courier New, monospace;
+   color: #cccccc;
 }
 
 code {


### PR DESCRIPTION
Meget fint projekt. Hermed et lille ændringsforslag.
Tekst i <code> er ulæselig, eks. på http://www.golang.dk/#om-programmering-og-paradigmer, sektionen "Pakker". Go-kode synes ikke påvirket, da der er separate regler til det.